### PR TITLE
chore: update devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,17 +50,16 @@
     "files": "src/tests/*.js"
   },
   "devDependencies": {
-    "bignumber.js": "3.0.1",
-    "chai": "3.5.0",
-    "coveralls": "2.11.9",
+    "bignumber.js": "9.1.1",
+    "chai": "4.3.7",
+    "coveralls": "2.13.3",
+    "cross-env": "5.2.1",
     "istanbul": "0.4.5",
-    "mocha": "3.2.0",
-    "zuul": "3.0.0",
-
-    "cross-env": "1.0.7",
-    "pre-commit": "1.1.3",
-    "rimraf": "2.3.4",
-    "webpack": "2.1.0-beta.15"
+    "mocha": "6.2.3",
+    "pre-commit": "1.2.2",
+    "rimraf": "3.0.2",
+    "webpack": "2.1.0-beta.15",
+    "zuul": "3.12.0"
   },
   "pre-commit": "build"
 }


### PR DESCRIPTION
bignumber.js: 3.0.1 -> 9.1.1
chai: 3.5.0 -> 4.3.7
coveralls: 2.11.9 -> 2.13.3
cross-env: 1.0.7 -> 5.2.1
mocha: 3.2.0 -> 6.2.3
pre-commit: 1.1.3 -> 1.2.2
rimraf: 2.3.4 -> 3.0.2
zuul: 3.0.0 -> 3.12.0

compatibility held with nodejs v6